### PR TITLE
2.7.3.1 - New Feature, item template file load from Active/(ChildTheme)

### DIFF
--- a/includes/extra_items_manager.php
+++ b/includes/extra_items_manager.php
@@ -78,7 +78,19 @@ foreach( $extra_items as $keyword ){
     $file = $items_directory_2 . $file_name . '.php';
     $file = apply_filters( 'wpto_template_loc', $file, $keyword, $type, $table_ID, $product, $file_name, $settings, $column_settings ); //@Filter Added 
     $file = apply_filters( 'wpto_template_loc_type_' . $type, $file, $keyword, $table_ID, $product, $file_name, $settings, $column_settings ); //@Filter Added
-    $file = $requested_file = apply_filters( 'wpto_template_loc_item_' . $keyword, $file,$type, $product, $table_ID, $settings,$column_settings );
+    $file = apply_filters( 'wpto_template_loc_item_' . $keyword, $file,$type, $product, $table_ID, $settings,$column_settings );
+    
+    /**
+     * File Template Final Filter 
+     * We have created this to make a new features, Where user will able to load template from Theme's Directory
+     * 
+     * To Load a new template of item from Theme, Use following location
+     * [YourTheme]/woo-product-table/items/[YourItemFileName].php
+     * 
+     * Functionality Added at includes/functions.php file.
+     */
+    $file = $requested_file = apply_filters( 'wpto_item_final_loc', $file, $file_name, $items_directory_2, $keyword, $table_ID, $settings, $items_permanent_dir );
+    
     if( !file_exists( $file ) ){
         $file = $items_permanent_dir . 'default.php';
         $file = apply_filters( 'wpto_defult_file_loc', $file, $keyword, $product, $table_ID );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -920,3 +920,36 @@ $css_code = ob_get_clean();
     }
 }
 add_action( 'wpto_table_wrapper_bottom', 'wpt_freeze_column_maintain',9910,4 );
+
+
+if( !function_exists( 'wpt_item_manage_from_theme' ) ){
+
+    /**
+     * Managing Final File Location 
+     * Actually if a user keep his Item Template file at His theme,
+     * That will get First Priority 
+     * Then template file will come from user defined template location
+     * We have used following Filter
+     * apply_filters( 'wpto_item_final_loc', $file, $file_name, $items_directory_2, $keyword, $table_ID, $settings, $items_permanent_dir );
+     * 
+     * To get Item's Template From Active Theme, Use following Directory
+     * [YourTheme]/woo-product-table/items/[YourItemFileName].php
+     * 
+     * Suppose, Item name is price, than location/directory from theme will be:
+     * [YourTheme]/woo-product-table/items/price.php
+     * 
+     * @param type $file
+     * @param type $items_directory_2
+     * @param type $file_name
+     * 
+     * @return type $file This Function will return $file Location of Items
+     */
+    function wpt_item_manage_from_theme( $file, $file_name ){
+        $file_frm_theme = get_stylesheet_directory() . '/woo-product-table/items/' . $file_name . '.php';
+        if( file_exists( $file_frm_theme ) ){
+            return $file_frm_theme;
+        }
+        return $file;
+    }
+}
+add_filter( 'wpto_item_final_loc', 'wpt_item_manage_from_theme', 1, 2 );

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -333,7 +333,7 @@ if( !function_exists( 'wpt_get_config_value' ) ){
     function wpt_get_config_value( $table_ID ){
         $config_value = $temp_config_value = get_option( 'wpt_configure_options' );
         $config = get_post_meta( $table_ID, 'config', true );
-        if( !empty( $config ) && is_array( $config ) ){
+        if( !empty( $config ) && is_array( $config ) && is_array( $config_value ) ){
             $config_value = array_merge( $config_value, $config );
         }
         $config_value = apply_filters( 'wpto_get_config_value', $config_value, $table_ID );

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -60,7 +60,9 @@ if( !function_exists( 'wpt_shortcode_generator' ) ){
             $search_n_filter = get_post_meta( $ID, 'search_n_filter', true );
             $pagination = get_post_meta( $ID, 'pagination', true );
             $config_value = wpt_get_config_value( $table_ID ); //Added at V5.0
-            array_unshift( $config_value, get_the_title( $ID ) ); //Added at V5.0
+            if( is_array( $config_value ) ){
+                array_unshift( $config_value, get_the_title( $ID ) ); //Added at V5.0
+            }
 
 
             /**

--- a/includes/table_row.php
+++ b/includes/table_row.php
@@ -79,7 +79,18 @@ foreach( $table_column_keywords as $keyword => $keyword_title ){
 
         $file = apply_filters( 'wpto_template_loc', $file, $keyword, $type, $table_ID, $product, $file_name, $column_settings, $settings ); //@Filter Added 
         $file = apply_filters( 'wpto_template_loc_type_' . $type, $file, $keyword, $table_ID, $product, $file_name, $column_settings, $settings ); //@Filter Added
-        $file  = $requested_file = apply_filters( 'wpto_template_loc_item_' . $keyword, $file, $table_ID, $product, $file_name, $column_settings, $settings ); //@Filter Changed added Args $fileName
+        $file  = apply_filters( 'wpto_template_loc_item_' . $keyword, $file, $table_ID, $product, $file_name, $column_settings, $settings ); //@Filter Changed added Args $fileName
+        
+        /**
+         * File Template Final Filter 
+         * We have created this to make a new features, Where user will able to load template from Theme's Directory
+         * 
+         * To Load a new template of item from Theme, Use following location
+         * [YourTheme]/woo-product-table/items/[YourItemFileName].php
+         * 
+         * Functionality Added at includes/functions.php file.
+         */
+        $file = $requested_file = apply_filters( 'wpto_item_final_loc', $file, $file_name, $items_directory_2, $keyword, $table_ID, $settings, $items_permanent_dir );
 
         if( !file_exists( $file ) ){
             $file = $items_permanent_dir . 'default.php';


### PR DESCRIPTION
     * Managing Final File Location 
     * Actually if a user keep his Item Template file at His theme,
     * That will get First Priority 
     * Then template file will come from user defined template location
     * We have used following Filter
     * apply_filters( 'wpto_item_final_loc', $file, $file_name, $items_directory_2, $keyword, $table_ID, $settings, $items_permanent_dir );
     * 
     * To get Item's Template From Active Theme, Use following Directory
     * [YourTheme]/woo-product-table/items/[YourItemFileName].php
     * 
     * Suppose, Item name is price, than location/directory from theme will be:
     * [YourTheme]/woo-product-table/items/price.php
     * 
     * @param type $file
     * @param type $items_directory_2
     * @param type $file_name
     * 
     * @return type $file This Function will return $file Location of Items