### PR TITLE
B2BKing group pricing conditions

### DIFF
--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -280,29 +280,59 @@ if( !function_exists( 'wpt_shortcode_generator' ) ){
             $args['order'] = $sort;
         }
 
-
+	/* Use b2bking group price support if available */ 
+	$user_id = get_current_user_id();
+	$is_b2b = get_user_meta($user_id, 'b2bking_b2buser', true);
+	    
         /**
          * Set Minimum Price for
          */
-        if ($min_price) {
-            $args['meta_query'][] = array(
-                'key' => '_price',
-                'value' => $min_price,
-                'compare' => '>=',
-                'type' => 'NUMERIC'
-            );
-        }
+	
+	if ($min_price) {
+		if ($is_b2b === 'yes'){
+			//b2bking b2b group price handling
+			$user_group = get_user_meta($user_id, 'b2bking_customergroup', true);
+			$args['meta_query'][] = array(
+			    'key' => 'b2bking_regular_product_price_group_'.$user_group,
+			    'value' => $min_price,
+			    'compare' => '>=',
+			    'type' => 'NUMERIC'
+			);
+		} else {
+			//default price handling
+			$args['meta_query'][] = array(
+			    'key' => '_price',
+			    'value' => $min_price,
+			    'compare' => '>=',
+			    'type' => 'NUMERIC'
+		   	);
+		}
+	}
+	    
+
 
         /**
          * Set Maximum Price for
          */
         if ($max_price) {
-            $args['meta_query'][] = array(
-                'key' => '_price',
-                'value' => $max_price,
-                'compare' => '<=',
-                'type' => 'NUMERIC'
-            );
+		if ($is_b2b === 'yes'){
+			//b2bking b2b group price handling
+			$user_group = get_user_meta($user_id, 'b2bking_customergroup', true);
+			$args['meta_query'][] = array(
+			    'key' => 'b2bking_regular_product_price_group_'.$user_group,
+			    'value' => $max_price,
+			    'compare' => '<=',
+			    'type' => 'NUMERIC'
+			);
+		} else {
+			//default price handling
+			$args['meta_query'][] = array(
+			    'key' => '_price',
+			    'value' => $max_price,
+			    'compare' => '<=',
+			    'type' => 'NUMERIC'
+			);
+		}
         }
 
         /**

--- a/includes/shortcode.php
+++ b/includes/shortcode.php
@@ -289,50 +289,26 @@ if( !function_exists( 'wpt_shortcode_generator' ) ){
          */
 	
 	if ($min_price) {
-		if ($is_b2b === 'yes'){
-			//b2bking b2b group price handling
-			$user_group = get_user_meta($user_id, 'b2bking_customergroup', true);
-			$args['meta_query'][] = array(
-			    'key' => 'b2bking_regular_product_price_group_'.$user_group,
-			    'value' => $min_price,
-			    'compare' => '>=',
-			    'type' => 'NUMERIC'
-			);
-		} else {
-			//default price handling
-			$args['meta_query'][] = array(
-			    'key' => '_price',
-			    'value' => $min_price,
-			    'compare' => '>=',
-			    'type' => 'NUMERIC'
-		   	);
-		}
+		$args['meta_query'][] = array(
+		//default price handling or B2Bking group prices
+		    'key' => ($is_b2b === 'yes')?'b2bking_regular_product_price_group_'.$user_group:'_price',
+		    'value' => $min_price,
+		    'compare' => '>=',
+		    'type' => 'NUMERIC'
+	   	);
 	}
-	    
-
 
         /**
          * Set Maximum Price for
          */
         if ($max_price) {
-		if ($is_b2b === 'yes'){
-			//b2bking b2b group price handling
-			$user_group = get_user_meta($user_id, 'b2bking_customergroup', true);
-			$args['meta_query'][] = array(
-			    'key' => 'b2bking_regular_product_price_group_'.$user_group,
-			    'value' => $max_price,
-			    'compare' => '<=',
-			    'type' => 'NUMERIC'
-			);
-		} else {
-			//default price handling
-			$args['meta_query'][] = array(
-			    'key' => '_price',
-			    'value' => $max_price,
-			    'compare' => '<=',
-			    'type' => 'NUMERIC'
-			);
-		}
+		//default price handling
+		$args['meta_query'][] = array(
+		    'key' => 'key' => ($is_b2b === 'yes')?'b2bking_regular_product_price_group_'.$user_group:'_price',
+		    'value' => $max_price,
+		    'compare' => '<=',
+		    'type' => 'NUMERIC'
+		);
         }
 
         /**
@@ -1428,3 +1404,4 @@ if( !function_exists( 'wpt_filter_box' ) ){
         return $html;
     }
 }
+?>


### PR DESCRIPTION
Added support for B2BKing group prices. 

Woo product table already worked together with B2BKing in showing the specific prices for the logged in user. However, whenever conditions of min or max were set in Woo product table, the filtering was done on the regular prices (not the B2B-group prices of the current logged-in user). This addition adds support for the group prices whenever B2BKing is active and the logged-in user is in a B2B group. It is as suggested by the B2BKing support team and verified working.
When B2BKing is not installed or the user is not logged-in as a B2B-group user, everything just falls back to the original behaviour.